### PR TITLE
allow passing in existing allure instance

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -16,8 +16,15 @@ class AllureReporter extends events.EventEmitter {
         this.config = config
         this.options = options
         this.outputDir = this.options.outputDir || 'allure-results'
-        this.allure = new Allure()
-        this.runtime = new Runtime(this.allure)
+
+        // allow to pass existing allure and runtime to make it accessable from outside
+        if(this.options.allure && this.options.runtime) {
+            this.allure = this.options.allure
+            this.runtime = this.options.runtime
+        } else {
+            this.allure = new Allure()
+            this.runtime = new Runtime(this.allure)
+        }
 
         this.allure.setOptions({
             targetDir: this.outputDir


### PR DESCRIPTION
Advanced Allure features (like Story/Feature labels) can't be used without access to `Allure` and `Runtime` instances. Passing them as option from a shared source allows to interact with Allure from within test suites. 

@dhoulker pointed out in a [comment](https://github.com/webdriverio/webdriverio/issues/532#issuecomment-146589905) why it's necessary to get global access to this instances.

Depends on https://github.com/webdriverio/wdio-allure-reporter/pull/8 because Allure [will access the current running test](https://github.com/allure-framework/allure-js-commons/blob/fe5153614b96fa468aa6508eb05682cab609face/runtime.js#L52) and therefore we need to deal with Allure on runtime.