### PR TITLE
add harmony flag to test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ For more information on WebdriverIO see the [homepage](http://webdriver.io).
 
 ## Development
 
-### Unit Test
-Unit Tests are running webdriverio multiple times using the wdio-allure-reporter and verifying the output.
+### Integration Tests
+Integration Tests are running webdriverio multiple times using the wdio-allure-reporter and verifying the output.
 ```
-grunt test
+npm test
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/reporter.js",
   "scripts": {
     "build": "grunt",
-    "test": "mocha test/specs --timeout 10000",
+    "test": "node --harmony_rest_parameters ./node_modules/grunt-cli/bin/grunt test",
     "prepublish": "npm prune && npm run build"
   },
   "repository": {


### PR DESCRIPTION
fixes #18 

```bash
node --harmony_rest_parameters ./node_modules/grunt-cli/bin/grunt test
```
executing the above command necessary to support ES Rest Parameters in current Node versions. Updated the `npm test` shortcut and the Readme. 
