### PR TITLE
little fixes for development environment

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -3,7 +3,7 @@ module.exports = function (grunt) {
         pkgFile: 'package.json',
         clean: {
             default: ['build'],
-            test: ['allure-results']
+            test: ['.allure-results']
         },
         babel: {
             options: {

--- a/test/helper.js
+++ b/test/helper.js
@@ -41,6 +41,9 @@ class Helper {
     }
 
     static disableOutput () {
+        if (process.env.FULL_OUTPUT) {
+            return
+        }
         const mockLog = (type) => (...message) => {
             this.logs[type].push(message.join(' '))
         }
@@ -60,6 +63,9 @@ class Helper {
     }
 
     static enableOutput () {
+        if (process.env.FULL_OUTPUT) {
+            return
+        }
         console.log = this.originalConsole.log
         console.warn = this.originalConsole.warn
         console.error = this.originalConsole.error


### PR DESCRIPTION
* There is one more wrong mention of `.allure-results` dir
* Sometimes I'd like to run tests with enabled output of tests from fixtures. Previously I just commented lines with `Helper.disableOutput()` call, but I think it would be better to make it configurable

Now you can run tests with `FULL_OUTPUT=true npm test` and get the full output from fixtures.