### PR TITLE
use babel to process test code

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -46,6 +46,7 @@ module.exports = function (grunt) {
         mochaTest: {
             test: {
                 options: {
+                    require: ['babel/register'],
                     reporter: 'spec',
                     quiet: false,
                     timeout: 8000

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/reporter.js",
   "scripts": {
     "build": "grunt",
-    "test": "node --harmony_rest_parameters ./node_modules/grunt-cli/bin/grunt test",
+    "test": "grunt test",
     "prepublish": "npm prune && npm run build"
   },
   "repository": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,75 +1,71 @@
-'use strict'
+import fs from 'fs'
+import path from 'path'
+import del from 'del'
+import Launcher from 'webdriverio/build/lib/launcher'
+import cheerio from 'cheerio'
 
-const fs = require('fs')
-const path = require('path')
-const del = require('del')
 const resultsDir = path.join(__dirname, '../.allure-results')
-const Launcher = require('webdriverio/build/lib/launcher')
-const cheerio = require('cheerio')
 
-class Helper {
-
-    static getResults () {
-        return Helper.getResultFiles('xml').map((file) => {
-            return cheerio.load(fs.readFileSync(path.join(resultsDir, file), 'utf-8'))
-        })
-    }
-
-    static getResultFiles (patterns) {
-        if (!Array.isArray(patterns)) {
-            patterns = [patterns]
-        }
-        return fs.readdirSync(resultsDir).filter((file) =>
-            patterns.some(pattern => file.endsWith('.' + pattern)))
-    }
-
-    static clean () {
-        return del(resultsDir)
-    }
-
-    static run (specs) {
-        Helper.disableOutput()
-
-        const launcher = new Launcher('./test/fixtures/wdio.conf.js', {
-            specs: specs.map(spec => `./test/fixtures/specs/${spec}.js`)
-        })
-
-        return launcher.run().then(result => {
-            Helper.enableOutput()
-            return Helper.getResults()
-        })
-    }
-
-    static disableOutput () {
-        if (process.env.FULL_OUTPUT) {
-            return
-        }
-        const mockLog = (type) => (...message) => {
-            this.logs[type].push(message.join(' '))
-        }
-        this.logs = {
-            log: [],
-            warn: [],
-            error: []
-        }
-        this.originalConsole = {
-            log: console.log,
-            warn: console.warn,
-            error: console.error
-        }
-        console.log = mockLog('log')
-        console.warn = mockLog('warn')
-        console.error = mockLog('error')
-    }
-
-    static enableOutput () {
-        if (process.env.FULL_OUTPUT) {
-            return
-        }
-        console.log = this.originalConsole.log
-        console.warn = this.originalConsole.warn
-        console.error = this.originalConsole.error
-    }
+export function getResults () {
+    return getResultFiles('xml').map((file) => {
+        return cheerio.load(fs.readFileSync(path.join(resultsDir, file), 'utf-8'))
+    })
 }
 
-module.exports = Helper
+export function getResultFiles (patterns) {
+    if (!Array.isArray(patterns)) {
+        patterns = [patterns]
+    }
+    return fs.readdirSync(resultsDir).filter((file) =>
+        patterns.some(pattern => file.endsWith('.' + pattern)))
+}
+
+export function clean () {
+    return del(resultsDir)
+}
+
+export function run (specs) {
+    disableOutput()
+
+    const launcher = new Launcher('./test/fixtures/wdio.conf.js', {
+        specs: specs.map(spec => `./test/fixtures/specs/${spec}.js`)
+    })
+
+    return launcher.run().then(() => {
+        enableOutput()
+        return getResults()
+    })
+}
+
+let logs, originalConsole
+
+function disableOutput () {
+    if (process.env.FULL_OUTPUT) {
+        return
+    }
+    const mockLog = (type) => (...message) => {
+        logs[type].push(message.join(' '))
+    }
+    logs = {
+        log: [],
+        warn: [],
+        error: []
+    }
+    originalConsole = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error
+    }
+    console.log = mockLog('log')
+    console.warn = mockLog('warn')
+    console.error = mockLog('error')
+}
+
+function enableOutput () {
+    if (process.env.FULL_OUTPUT) {
+        return
+    }
+    console.log = originalConsole.log
+    console.warn = originalConsole.warn
+    console.error = originalConsole.error
+}

--- a/test/specs/after.js
+++ b/test/specs/after.js
@@ -1,13 +1,11 @@
-'use strict'
-
-let expect = require('chai').expect
-let helper = require('../helper')
+import {expect} from 'chai'
+import {clean, run} from '../helper'
 
 describe('after hooks', () => {
-    beforeEach(helper.clean)
+    beforeEach(clean)
 
     it('should not appear in results when it is passing', () => {
-        return helper.run(['after-all-passing']).then((results) => {
+        return run(['after-all-passing']).then((results) => {
             const result = results[0]
             expect(result('test-case')).to.have.lengthOf(1)
             expect(result('test-case > name').text()).to.equal('with passing test')
@@ -16,7 +14,7 @@ describe('after hooks', () => {
     })
 
     it('should report failed after-all hook', () => {
-        return helper.run(['after-all-failing']).then((results) => {
+        return run(['after-all-failing']).then((results) => {
             expect(results).to.have.lengthOf(1)
 
             const result = results[0]
@@ -33,7 +31,7 @@ describe('after hooks', () => {
     })
 
     it('should report after-each hook', () => {
-        return helper.run(['after-each-failing']).then((results) => {
+        return run(['after-each-failing']).then((results) => {
             expect(results).to.have.lengthOf(1)
 
             const result = results[0]

--- a/test/specs/before.js
+++ b/test/specs/before.js
@@ -1,13 +1,11 @@
-'use strict'
-
-let expect = require('chai').expect
-let helper = require('../helper')
+import {expect} from 'chai'
+import {clean, run} from '../helper'
 
 describe('before hooks', () => {
-    beforeEach(helper.clean)
+    beforeEach(clean)
 
     it('should not appear in results when it is passing', () => {
-        return helper.run(['before-all-passing']).then((results) => {
+        return run(['before-all-passing']).then((results) => {
             expect(results).to.have.lengthOf(1)
 
             const result = results[0]
@@ -18,7 +16,7 @@ describe('before hooks', () => {
     })
 
     it('should report failed before-all hook', () => {
-        return helper.run(['before-all-failing']).then((results) => {
+        return run(['before-all-failing']).then((results) => {
             expect(results).to.have.lengthOf(1)
 
             const result = results[0]
@@ -29,7 +27,7 @@ describe('before hooks', () => {
     })
 
     it('should report before-each hook', () => {
-        return helper.run(['before-each-failing']).then((results) => {
+        return run(['before-each-failing']).then((results) => {
             expect(results).to.have.lengthOf(1)
 
             const result = results[0]

--- a/test/specs/parallel.js
+++ b/test/specs/parallel.js
@@ -1,12 +1,11 @@
-'use strict'
-const helper = require('../helper')
-const expect = require('chai').expect
+import {expect} from 'chai'
+import {clean, run} from '../helper'
 
 describe('parallel', () => {
-    beforeEach(helper.clean)
+    beforeEach(clean)
 
     it('should run several suites in parallel', () => {
-        return helper.run(['broken', 'failing']).then((results) => {
+        return run(['broken', 'failing']).then((results) => {
             expect(results).to.have.lengthOf(2)
             const startTimes = results.map(result => result('test-case').attr('start'))
             const stopTimes = results.map(result => result('test-case').attr('stop'))

--- a/test/specs/screenshot.js
+++ b/test/specs/screenshot.js
@@ -1,37 +1,35 @@
-'use strict'
-
-let expect = require('chai').expect
-let helper = require('../helper')
+import {expect} from 'chai'
+import {clean, run, getResultFiles} from '../helper'
 
 describe('Screenshots', () => {
-    beforeEach(helper.clean)
+    beforeEach(clean)
 
     it('can be taken during a test', () => {
-        return helper.run(['screenshot']).then((results) => {
+        return run(['screenshot']).then((results) => {
             expect(results).to.have.lengthOf(1)
             expect(results[0]('test-case')).to.have.lengthOf(1)
 
-            const screenshotFiles = helper.getResultFiles('png')
+            const screenshotFiles = getResultFiles('png')
             expect(screenshotFiles, 'no screenshot files attached').to.have.lengthOf(1)
             expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(1)
         })
     })
 
     it('can take screenshot before each test and attach it accordingly', () => {
-        return helper.run(['screenshot-before-each']).then((results) => {
+        return run(['screenshot-before-each']).then((results) => {
             expect(results[0]('test-case')).to.have.lengthOf(2)
             expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(2)
 
-            const screenshotFiles = helper.getResultFiles('png')
+            const screenshotFiles = getResultFiles('png')
             expect(screenshotFiles, 'no screenshot files attached').to.have.lengthOf(2)
         })
     })
 
     it('can be taken in an "before all" hook', () => {
-        return helper.run(['screenshot-before-all']).then((results) => {
+        return run(['screenshot-before-all']).then((results) => {
             expect(results).to.have.lengthOf(1)
 
-            let screenshotFiles = helper.getResultFiles(['jpg', 'png'])
+            let screenshotFiles = getResultFiles(['jpg', 'png'])
             expect(screenshotFiles, 'no screenshot files attached').to.have.lengthOf(1)
         })
     })

--- a/test/specs/suite.js
+++ b/test/specs/suite.js
@@ -1,12 +1,11 @@
-'use strict'
-const expect = require('chai').expect
-const helper = require('../helper')
+import {expect} from 'chai'
+import {clean, run} from '../helper'
 
 describe('Suites', () => {
-    beforeEach(helper.clean)
+    beforeEach(clean)
 
     it('should report two suites from one file', () => {
-        return helper.run(['two-passing-in-one-suite']).then((results) => {
+        return run(['two-passing-in-one-suite']).then((results) => {
             expect(results).to.have.lengthOf(2)
             results.forEach(result => {
                 expect(result('ns2\\:test-suite > name').text())
@@ -18,7 +17,7 @@ describe('Suites', () => {
     })
 
     it('should split nested suites', () => {
-        return helper.run(['nested-suite']).then(results => {
+        return run(['nested-suite']).then(results => {
             expect(results).to.have.lengthOf(2)
 
             const suiteNames = results.map(result => result('ns2\\:test-suite > name').text())

--- a/test/specs/test-case.js
+++ b/test/specs/test-case.js
@@ -1,11 +1,11 @@
-const expect = require('chai').expect
-const helper = require('../helper')
+import {expect} from 'chai'
+import {clean, run} from '../helper'
 
 describe('test cases', () => {
-    beforeEach(helper.clean)
+    beforeEach(clean)
 
     it('should detect passed test case', () => {
-        return helper.run(['passing']).then((results) => {
+        return run(['passing']).then((results) => {
             expect(results).to.have.lengthOf(1)
             const result = results[0]
 
@@ -17,7 +17,7 @@ describe('test cases', () => {
     })
 
     it('should detect broken test case', () => {
-        return helper.run(['broken']).then((results) => {
+        return run(['broken']).then((results) => {
             expect(results).to.have.lengthOf(1)
             const result = results[0]
 
@@ -29,7 +29,7 @@ describe('test cases', () => {
     })
 
     it('should detect passed failed case', () => {
-        return helper.run(['failing']).then((results) => {
+        return run(['failing']).then((results) => {
             expect(results).to.have.lengthOf(1)
             const result = results[0]
 


### PR DESCRIPTION
As far as we use Babel to process source code, it would be nice to use it for test code as well.

Then we stop worrying about unsupported features in runtime, and start use es6 imports, which give a really better fit for our `helper.js` module.

:warning: files in `fixstures` dir are still uncovered by Babel, because I am not sure, that I can process them.