### PR TITLE
Add the ability to save custom attachments to steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,46 @@ exports.config = {
 
 `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
 
+## Custom attachments
+
+You can save custom attachments to tests/steps by calling `process.send` to `allure:attachment` within your hook:
+
+```js
+afterStep: function (step) {
+    var serverLogs = getServerLogsSomehow();
+    
+    process.send({
+        event: 'allure:attachment',
+        test: step.getStep().getName(), // The name of the test to attach this to
+        name: 'Server logs', // The name that this attachment should get in the report
+        content: '<pre style="font-family: SFMono-Regular, Consolas, ' +
+            '\'Liberation Mono\', Menlo, Courier, monospace; font-size: 12px">' +
+            serverLogs.replace(/\n/g, '<br>') + '</pre>',
+        mimeType: 'text/html',
+    });
+}
+```
+
+Until [webdriverio/webdriverio#1893](https://github.com/webdriverio/webdriverio/pull/1893) lands, there is no certain way to connect your hook with the specific Allure report being assembled for that test run; for now, we check the current open Allure reports for the one that has the most recent test with the name you send here via the `test` property, and this attachment is added to that test. If by coincidence there are two in-progress Allure reports that both have a most-recent test with the same name, the attachment will only be added to the first one.
+
+If you send HTML, Allure will display it as rich HTML—even with images, if you include an `img src` with a base64-encoded data URI. This is another way to include custom images in your output:
+
+```js
+afterStep: function (step) {
+    var image = new Buffer(require('fs').readFileSync('download.png')).toString('base64');
+    
+    process.send({
+        event: 'allure:attachment',
+        test: step.getStep().getName(),
+        name: 'Downloaded image',
+        content: '<img src="data:image/png;base64,' + image + '">',
+        mimeType: 'text/html',
+    });
+}
+```
+
+If you leave out `mimeType`, plain text is assumed. If you send `application/json`, the JSON will be pretty-printed with four spaces.
+
 ## Displaying the report
 The results can be consumed by any of the [reporting tools](http://wiki.qatools.ru/display/AL/Reporting) offered by Allure. For example:
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -127,6 +127,34 @@ class AllureReporter extends events.EventEmitter {
                 allure.getCurrentSuite().testcases.pop()
             }
         })
+
+        this.on('allure:attachment', (attachment) => {
+            if (attachment.content == null) {
+                return
+            }
+
+            var allure = null
+            if (attachment.cid != null) {
+                allure = this.getAllure(attachment.cid)
+            } else if (attachment.test != null) {
+                allure = this.getAllureFromTestName(attachment.test)
+            } else {
+                return
+            }
+
+            if (allure == null) {
+                return
+            }
+
+            attachment.name = attachment.name || 'Attachment'
+            attachment.mimeType = attachment.mimeType || 'text/plain'
+
+            if (attachment.mimeType === 'application/json') {
+                this.dumpJSON(allure, attachment.name, attachment.content)
+            } else {
+                allure.addAttachment(attachment.name, attachment.content, attachment.mimeType)
+            }
+        })
     }
 
     getAllure (cid) {
@@ -138,6 +166,16 @@ class AllureReporter extends events.EventEmitter {
         allure.setOptions({ targetDir: this.options.outputDir || 'allure-results' })
         this.allures[cid] = allure
         return this.allures[cid]
+    }
+
+    getAllureFromTestName (name) {
+        for (let cid in this.allures) {
+            if (this.isAnyTestRunning(this.allures[cid]) && this.allures[cid].getCurrentTest().name === name) {
+                // If there happens to be more than one `allure` with a current test matching `name`, this will return only the first one
+                return this.allures[cid]
+            }
+        }
+        return null
     }
 
     isAnyTestRunning (allure) {


### PR DESCRIPTION
Implementation based on https://github.com/webdriverio/wdio-allure-reporter/issues/25#issuecomment-284858509. This provides a way to add arbitrary data (text, JSON, HTML including images via data URIs) to tests in Allure reports.

I couldn’t find a way to get `cid` from within my test hooks, which is probably why https://github.com/webdriverio/webdriverio/pull/1893 was submitted. So for now the listener checks for `cid` if provided, and test name otherwise, and picks the first `allure` that has a current test with the same name as the message. This works in my testing. I’ve also added detailed instructions in the README.