### PR TITLE
#44 fix reporter crash in case when selenium returns error in /session/:sessionId/screenshot response

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -95,9 +95,9 @@ class AllureReporter extends events.EventEmitter {
                 return
             }
 
-            if (command.requestOptions.uri.path.match(/\/wd\/hub\/session\/[^/]*\/screenshot/)) {
+            if (command.requestOptions.uri.path.match(/\/wd\/hub\/session\/[^/]*\/screenshot/) && command.body.value) {
                 allure.addAttachment('Screenshot', Buffer.from(command.body.value, 'base64'))
-            } else {
+            } else if (command.body) {
                 this.dumpJSON(allure, 'Response', command.body)
             }
 


### PR DESCRIPTION
Check screenshot response has correct body.
Fix for issues https://github.com/webdriverio/wdio-allure-reporter/issues/48, https://github.com/webdriverio/wdio-allure-reporter/issues/44

I applied this fix in my fork and it helps - I haven't ran into this issue during last 3-4 months.
Unfortunately I can't proof my fix by corresponding test - phantomjs works well on described cases.