### PR TITLE
added runner:screenshot event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ allure generate [allure_output_dir] && allure open
 This will generate a report (by default in `./allure-report`), and open it in your browser:
 ![screenshot 2016-02-05 10.15.57.png](./docs/images/browser.png)
 
+### Add Screenshots
+Screenshots can be attached to the report by using the `saveScreenshot` function from WebDriverIO in afterStep hook.
+```js
+//...
+var name = 'ERROR-chrome-' + Date.now()
+browser.saveScreenshot('./errorShots/' + name + '.png')
+//...
+```
+As shown in the example above, when this function is called, a screenshot image will be created and saved in the directory, as well as attached to the allure report.
+
 ----
 
 For more information on WebdriverIO see the [homepage](http://webdriver.io).

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -104,6 +104,12 @@ class AllureReporter extends events.EventEmitter {
             allure.endStep('passed')
         })
 
+        this.on('runner:screenshot', (command) => {
+            const allure = this.getAllure(command.cid)
+
+            allure.addAttachment('screenshot-' + command.filename, Buffer.from(command.data, 'base64'))
+        })
+
         this.on('hook:start', (hook) => {
             const allure = this.getAllure(hook.cid)
 

--- a/test/fixtures/specs/screenshot-after-each.js
+++ b/test/fixtures/specs/screenshot-after-each.js
@@ -1,0 +1,19 @@
+'use strict'
+const expect = require('chai').expect
+
+describe('Screenshot during "after" hook', () => {
+    afterEach(() => {
+        return browser.screenshot()
+    })
+
+    it('with passing test', () => {
+        return browser
+            .url('/index.html')
+            .waitForExist('#clickable')
+            .click('#clickable')
+            .getValue('#result')
+            .then((value) => {
+                expect(value).to.be.equal('1')
+            })
+    })
+})

--- a/test/fixtures/specs/screenshot-after.js
+++ b/test/fixtures/specs/screenshot-after.js
@@ -1,0 +1,19 @@
+'use strict'
+const expect = require('chai').expect
+
+describe('Screenshot during "after" hook', () => {
+    after(() => {
+        return browser.screenshot()
+    })
+
+    it('with passing test', () => {
+        return browser
+            .url('/index.html')
+            .waitForExist('#clickable')
+            .click('#clickable')
+            .getValue('#result')
+            .then((value) => {
+                expect(value).to.be.equal('1')
+            })
+    })
+})

--- a/test/specs/screenshot.js
+++ b/test/specs/screenshot.js
@@ -33,4 +33,15 @@ describe('Screenshots', () => {
             expect(screenshotFiles, 'no screenshot files attached').to.have.lengthOf(1)
         })
     })
+
+    it('can be taken in an "after" hook', () => {
+        return run(['screenshot-after']).then((results) => {
+            expect(results).to.have.lengthOf(1)
+            expect(results[0]('test-case')).to.have.lengthOf(2)
+
+            const screenshotFiles = getResultFiles('png')
+            expect(screenshotFiles, 'no screenshot files attached').to.have.lengthOf(1)
+            expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(1)
+        })
+    })
 })

--- a/test/specs/screenshot.js
+++ b/test/specs/screenshot.js
@@ -44,4 +44,15 @@ describe('Screenshots', () => {
             expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(1)
         })
     })
+
+    it('can be taken in an "after each" hook', () => {
+        return run(['screenshot-after-each']).then((results) => {
+            expect(results).to.have.lengthOf(1)
+            expect(results[0]('test-case')).to.have.lengthOf(1)
+
+            const screenshotFiles = getResultFiles('png')
+            expect(screenshotFiles, 'no screenshot files attached').to.have.lengthOf(1)
+            expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(1)
+        })
+    })
 })


### PR DESCRIPTION
With this event listener, users can directly attach screenshots to the allure report, especially when a step is not successful, an error shot would be useful. Users can simply call the `saveScreenshot` function from wdio in e.g. `afterStep` hook to achieve it. Based on #25.