### PR TITLE
Add the ability to save custom attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 # Unit test results
 .allure-results/
 screenshots/
+
+# JetBrains IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -99,4 +99,8 @@ npm test
 ## Supported Allure API
 * `feature(featureName)` – assign feature to test
 * `addEnvironment(name, value)` – save environment value
+* `createAttachement(name, content, [type])` – save attachment to test.
+    * `name` (*String*) - attachment name. `Test attachment`by default
+    * `content` – attachment content.
+    * `type` (*String*, optional) – attachment MIME-type, `text/plain` by default
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm test
 * `feature(featureName)` – assign feature to test
 * `addEnvironment(name, value)` – save environment value
 * `createAttachement(name, content, [type])` – save attachment to test.
-    * `name` (*String*) - attachment name. `Test attachment`by default
+    * `name` (*String*) - attachment name.
     * `content` – attachment content.
     * `type` (*String*, optional) – attachment MIME-type, `text/plain` by default
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -145,6 +145,25 @@ class AllureReporter extends events.EventEmitter {
             const test = allure.getCurrentTest()
             test.addParameter('environment-variable', name, value)
         })
+
+        this.on('allure:attachment', ({cid, name, content, type}) => {
+            if (content == null) {
+                return
+            }
+
+            var allure = null
+            allure = this.getAllure(cid)
+
+            if (allure == null) {
+                return
+            }
+
+            if (type === 'application/json') {
+                this.dumpJSON(allure, name, content)
+            } else {
+                allure.addAttachment(name, content, type)
+            }
+        })
     }
 
     getAllure (cid) {

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -8,11 +8,16 @@ export function addEnvironment (name, value) {
     tellReporter('allure:addEnvironment', { name, value })
 }
 
+export function createAttachment (name = 'Test attachment', content, type = 'text/plain') {
+    tellReporter('allure:attachment', {name, content, type})
+}
+
 function tellReporter (event, msg = {}) {
     process.send({ event, ...msg })
 }
 
 export default {
     feature,
-    addEnvironment
+    addEnvironment,
+    createAttachment
 }

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -8,7 +8,7 @@ export function addEnvironment (name, value) {
     tellReporter('allure:addEnvironment', { name, value })
 }
 
-export function createAttachment (name = 'Test attachment', content, type = 'text/plain') {
+export function createAttachment (name, content, type = 'text/plain') {
     tellReporter('allure:attachment', {name, content, type})
 }
 

--- a/test/fixtures/specs/create-attachment.js
+++ b/test/fixtures/specs/create-attachment.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const {createAttachment} = require('./../../../build/runtime')
+
+describe('Suite with attachments', () => {
+    it('Add attachment with plain text attachment', () => {
+        createAttachment('Plain text attachment', 'Plain text attachment')
+    })
+
+    it('Add attachment with JSON type', () => {
+        createAttachment('JSON file attachment', {id: 1, name: 'Test user'}, 'application/json')
+    })
+
+    it('Add attachment with HTML type', () => {
+        const html = '<html>\n' +
+            '<body>\n' +
+            '\n' +
+            '<h1>My First Heading</h1>\n' +
+            '\n' +
+            '<p>My first paragraph.</p>\n' +
+            '\n' +
+            '</body>\n' +
+            '</html>\n'
+
+        createAttachment('HTML file attachment', html, 'text/html')
+    })
+})

--- a/test/specs/create-attachment.js
+++ b/test/specs/create-attachment.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai'
+import {clean, getResultFiles, run} from '../helper'
+
+describe('create attachment', () => {
+    beforeEach(clean)
+
+    it('should create attachments in test cases', () => {
+        return run(['create-attachment']).then((results) => {
+            expect(results).to.have.lengthOf(1)
+            const result = results[0]
+
+            const txtAttachment = getResultFiles('txt')
+            expect(txtAttachment, 'Plain text attachment file was not generated').to.have.lengthOf(1)
+            expect(result('test-case attachment[title="Plain text attachment"]'),
+                'Plain text attachment file was not added to general xml report').to.have.lengthOf(1)
+
+            const jsonAttachment = getResultFiles('json')
+            expect(jsonAttachment, 'JSON attachment file was not generated').to.have.lengthOf(1)
+            expect(result('test-case attachment[title="JSON file attachment"]'),
+                'JSON attachment file was not added to general xml report').to.have.lengthOf(1)
+
+            const htmlAttachment = getResultFiles('html')
+            expect(htmlAttachment, 'HTML attachment file was not generated').to.have.lengthOf(1)
+            expect(result('test-case attachment[title="HTML file attachment"]'),
+                'HTML attachment file was not added to general xml report').to.have.lengthOf(1)
+        })
+    })
+})


### PR DESCRIPTION
This is an updated version of pull request https://github.com/webdriverio/wdio-allure-reporter/pull/39. The author of original PR seems is hard to reach, so I decided to create a new one.

I rewrote code according to requested changes and added simple tests for `createAttachment` feature.
