### PR TITLE
Screenshots don't attach properly if selenium servers runs on root url

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -95,7 +95,7 @@ class AllureReporter extends events.EventEmitter {
                 return
             }
 
-            if (command.requestOptions.uri.path.match(/\/wd\/hub\/session\/[^/]*\/screenshot/) && command.body.value) {
+            if (command.requestOptions.uri.path.match(/\/session\/[^/]*\/screenshot/) && command.body.value) {
                 allure.addAttachment('Screenshot', Buffer.from(command.body.value, 'base64'))
             } else if (command.body) {
                 this.dumpJSON(allure, 'Response', command.body)


### PR DESCRIPTION
Fix for case when selenium server runs in a root

Chromedriver selenium servers runs on "/" path. In such case screenshoths were attached as json.