### PR TITLE
Add Allure api for users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+const AllureReporter = require('./build/reporter')
+const AllureApi = require('./build/runtime.js')
+
+exports.default = AllureReporter
+module.exports = exports['default']
+module.exports.AllureApi = { AllureApi }

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,12 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
+    "allure-commandline": {
+      "version": "2.5.0",
+      "resolved": "http://dbi-nexus.mbank.pl:80/artifactory/api/npm/npm/allure-commandline/-/allure-commandline-2.5.0.tgz",
+      "integrity": "sha1-lB2A2FTk9xMe0CDbPnvsm3V2WAA=",
+      "dev": true
+    },
     "allure-js-commons": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-1.3.1.tgz",
@@ -1183,7 +1189,7 @@
     },
     "babel-plugin-transform-function-bind": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
+      "resolved": "http://dbi-nexus.mbank.pl:80/artifactory/api/npm/npm/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz",
       "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wdio-allure-reporter",
   "version": "0.3.0",
   "description": "A WebdriverIO plugin. Report results in Allure format.",
-  "main": "build/reporter.js",
+  "main": "index.js",
   "scripts": {
     "build": "run-s clean compile",
     "clean": "rm -rf ./build ./coverage ./.allure-results ./screenshots",


### PR DESCRIPTION
Hi, Currently if users want to use allure api needs to reference runtime.js from node_modules directory:
```
const allure = require('./node_modules/wdio-allure-reporter/build/runtime');
```
It looks realy ugly, so I think that we need to fix it, adding index.js to root of project where by default will be exported Reporter for wdio, and additionaly AllureApi for users.

I prepare POC of concept. It didn't work  :/

When I do in my app:
```
import { AllureApi } from 'wdio-allure-reporter';

it('test', () => {
    console.log('api', AllureApi);
    AllureApi.feature('Feature');
  });
```
console throws:
```
api { AllureApi:
   { feature: [Function: feature],
     addEnvironment: [Function: addEnvironment],
     addDescription: [Function: addDescription],
     createAttachment: [Function: createAttachment],
     story: [Function: story],
     default:
      { feature: [Function: feature],
        addEnvironment: [Function: addEnvironment],
        createAttachment: [Function: createAttachment],
        story: [Function: story] } } }
```

I am not a js master and need your help to fix it ...
Please help