### PR TITLE
Add feature/story labels in test:start listener for cucumber

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -49,8 +49,8 @@ class AllureReporter extends events.EventEmitter {
             currentTest.addParameter('environment-variable', 'spec files', JSON.stringify(test.specs))
 
             if (test.featureName && test.scenarioName) {
-                currentTest.addLabel('feature', test.featureName);
-                currentTest.addLabel('story', test.scenarioName);
+                currentTest.addLabel('feature', test.featureName)
+                currentTest.addLabel('story', test.scenarioName)
             }
 
             // Analytics labels More: https://github.com/allure-framework/allure2/blob/master/Analytics.md

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -48,6 +48,11 @@ class AllureReporter extends events.EventEmitter {
             currentTest.addParameter('environment-variable', 'capabilities', JSON.stringify(test.runner[test.cid]))
             currentTest.addParameter('environment-variable', 'spec files', JSON.stringify(test.specs))
 
+            if (test.featureName && test.scenarioName) {
+                currentTest.addLabel('feature', test.featureName);
+                currentTest.addLabel('story', test.scenarioName);
+            }
+
             // Analytics labels More: https://github.com/allure-framework/allure2/blob/master/Analytics.md
             currentTest.addLabel('language', 'javascript')
             currentTest.addLabel('framework', 'wdio')

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,12 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
+    "allure-commandline": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/allure-commandline/-/allure-commandline-2.5.0.tgz",
+      "integrity": "sha1-lB2A2FTk9xMe0CDbPnvsm3V2WAA=",
+      "dev": true
+    },
     "allure-js-commons": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-1.3.1.tgz",
@@ -230,6 +236,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
       "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
@@ -442,6 +454,17 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
+    },
+    "assertion-error-formatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error-formatter/-/assertion-error-formatter-2.0.1.tgz",
+      "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "pad-right": "0.2.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "async-each": {
       "version": "1.0.1",
@@ -1492,6 +1515,12 @@
         }
       }
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1769,6 +1798,23 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
       "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
       "dev": true
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "dev": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true
+        }
+      }
     },
     "cli-truncate": {
       "version": "0.2.1",
@@ -2152,6 +2198,59 @@
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
       "dev": true
     },
+    "cucumber": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/cucumber/-/cucumber-2.3.1.tgz",
+      "integrity": "sha1-N5GlH/0MYUYq1X/bjtER1VtRzeM=",
+      "dev": true,
+      "requires": {
+        "assertion-error-formatter": "2.0.1",
+        "babel-runtime": "6.26.0",
+        "bluebird": "3.5.1",
+        "cli-table": "0.3.1",
+        "colors": "1.1.2",
+        "commander": "2.11.0",
+        "cucumber-expressions": "3.0.0",
+        "cucumber-tag-expressions": "1.1.1",
+        "duration": "0.2.0",
+        "figures": "2.0.0",
+        "gherkin": "4.1.3",
+        "glob": "7.1.2",
+        "indent-string": "3.2.0",
+        "is-generator": "1.0.3",
+        "is-stream": "1.1.0",
+        "lodash": "4.17.4",
+        "mz": "2.7.0",
+        "progress": "2.0.0",
+        "resolve": "1.5.0",
+        "stack-chain": "1.3.7",
+        "stacktrace-js": "2.0.0",
+        "string-argv": "0.0.2",
+        "upper-case-first": "1.1.2",
+        "util-arity": "1.1.0",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
+      }
+    },
+    "cucumber-expressions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cucumber-expressions/-/cucumber-expressions-3.0.0.tgz",
+      "integrity": "sha1-TPQkgT2uOWzJ2rcUuBBLRZvvwyw=",
+      "dev": true
+    },
+    "cucumber-tag-expressions": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cucumber-tag-expressions/-/cucumber-tag-expressions-1.1.1.tgz",
+      "integrity": "sha1-f1x7cACbwrZmWRv+ZIVFeL7e6Fo=",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2159,6 +2258,15 @@
       "dev": true,
       "requires": {
         "array-find-index": "1.0.2"
+      }
+    },
+    "d": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.38"
       }
     },
     "dashdash": {
@@ -2355,6 +2463,16 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "duration": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.0.tgz",
+      "integrity": "sha1-X5xN+q//ZV3phhEu/iXFl43YUUY=",
+      "dev": true,
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.38"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -2401,6 +2519,15 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.1.tgz",
+      "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
+      "dev": true,
+      "requires": {
+        "stackframe": "1.0.4"
+      }
+    },
     "es-abstract": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
@@ -2425,11 +2552,64 @@
         "is-symbol": "1.0.1"
       }
     },
+    "es5-ext": {
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-symbol": "3.1.1"
+      },
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.38"
+          }
+        }
+      }
+    },
     "es6-promise": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
       "integrity": "sha1-9yLXdpr4i9M7wT7GYF4fkpZrgtk=",
       "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      },
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "dev": true,
+          "requires": {
+            "es5-ext": "0.10.38"
+          }
+        }
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3976,6 +4156,12 @@
         "assert-plus": "1.0.0"
       }
     },
+    "gherkin": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/gherkin/-/gherkin-4.1.3.tgz",
+      "integrity": "sha1-EWh9uTl235djMSWmsiKKGkv9+iQ=",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -4442,6 +4628,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
       "dev": true
     },
     "is-glob": {
@@ -5405,6 +5597,12 @@
         }
       }
     },
+    "mockery": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5416,6 +5614,17 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "object-assign": "4.1.1",
+        "thenify-all": "1.6.0"
+      }
     },
     "nan": {
       "version": "2.8.0",
@@ -5998,6 +6207,15 @@
         "semver": "5.4.1"
       }
     },
+    "pad-right": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
+      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
+      "dev": true,
+      "requires": {
+        "repeat-string": "1.6.1"
+      }
+    },
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -6514,8 +6732,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -6849,6 +7066,56 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU=",
+      "dev": true
+    },
+    "stack-generator": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.2.tgz",
+      "integrity": "sha512-Qj3X+vY7qQ0OOLQomEihHk5SSnSPCI3z4RfB8kDk9lnzwznBODlkWODitEo8sHpp0a2VdSy3yuJkabNsQN5RGA==",
+      "dev": true,
+      "requires": {
+        "stackframe": "1.0.4"
+      }
+    },
+    "stackframe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
+      "integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==",
+      "dev": true
+    },
+    "stacktrace-gps": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
+      "integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "1.0.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
+      "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
+      "dev": true,
+      "requires": {
+        "error-stack-parser": "2.0.1",
+        "stack-generator": "2.0.2",
+        "stacktrace-gps": "3.0.2"
+      }
+    },
     "stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
@@ -6866,6 +7133,12 @@
       "requires": {
         "any-observable": "0.2.0"
       }
+    },
+    "string-argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -7090,6 +7363,24 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": "3.3.0"
+      }
+    },
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
@@ -7307,6 +7598,12 @@
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
+    "util-arity": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/util-arity/-/util-arity-1.1.0.tgz",
+      "integrity": "sha1-WdAa8f2z/t4KxOYysKtfbOl8kzA=",
+      "dev": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7359,6 +7656,47 @@
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
       "dev": true
+    },
+    "wdio-cucumber-framework": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/wdio-cucumber-framework/-/wdio-cucumber-framework-1.0.3.tgz",
+      "integrity": "sha512-bLXFB+YRedrGLDpsZPm2ev1HdxLo6YzDZmvu+OHtyBsn1Y2Aw0WQ2EM33dTo5IrY6x93M3F8e7MC+q6HNIscqQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.25.0",
+        "cucumber": "2.3.1",
+        "mockery": "2.1.0",
+        "wdio-sync": "0.7.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.25.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+          "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+          "dev": true,
+          "requires": {
+            "core-js": "2.5.3",
+            "regenerator-runtime": "0.10.5"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        },
+        "wdio-sync": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/wdio-sync/-/wdio-sync-0.7.0.tgz",
+          "integrity": "sha1-L7B9JQEh3IH1Y1MWVCw8SaEiAWg=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "6.25.0",
+            "fibers": "2.0.0",
+            "object.assign": "4.1.0"
+          }
+        }
+      }
     },
     "wdio-dot-reporter": {
       "version": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -63,11 +63,12 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
+    "node-static": "^0.7.10",
     "np": "~2.18.0",
     "npm-run-all": "~4.1.0",
-    "wdio-phantomjs-service": "^0.2.2",
+    "wdio-cucumber-framework": "^1.0.3",
     "wdio-mocha-framework": "^0.5.12",
-    "node-static": "^0.7.10",
+    "wdio-phantomjs-service": "^0.2.2",
     "webdriverio": "4.8.0"
   },
   "contributors": [

--- a/test/fixtures/features/passing.feature
+++ b/test/fixtures/features/passing.feature
@@ -1,0 +1,10 @@
+Feature: A passing feature
+
+    In order to successfully generate a report
+    As a tester
+    I want to run a passing scenario
+
+    Scenario: A passing scenario
+        Given I visit "/index.html"
+        When I click the clickable region
+        Then I should get the result: 1

--- a/test/fixtures/features/steps/passing-steps.js
+++ b/test/fixtures/features/steps/passing-steps.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai'
+import { defineSupportCode } from 'cucumber'
+
+defineSupportCode(({ Given, When, Then }) => {
+    Given('I visit {stringInDoubleQuotes}', (url) => browser.url(url))
+
+    When('I click the clickable region', () => browser.click('#clickable'))
+
+    Then('I should get the result: {int}', (num) => {
+        const result = browser.getValue('#result')
+        expect(result).to.be.equal(num.toString())
+    })
+})

--- a/test/fixtures/wdio.conf.cucumber.js
+++ b/test/fixtures/wdio.conf.cucumber.js
@@ -1,0 +1,28 @@
+var allureReporter = require('../../build/reporter')
+allureReporter.reporterName = 'allure'
+
+exports.config = {
+    baseUrl: 'http://localhost:8080',
+    coloredLogs: true,
+    logLevel: 'silent',
+    services: ['phantomjs'],
+    reporters: [allureReporter],
+    framework: 'cucumber',
+    cucumberOpts: {
+        timeout: 20000,
+        require: ['test/fixtures/features/steps/passing-steps.js'],
+        compiler: [
+            'js:babel-register'
+        ]
+    },
+    reporterOptions: {
+        allure: {
+            outputDir: '.allure-results'
+        }
+    },
+    sync: true,
+    screenshotPath: './screenshots',
+    capabilities: [{
+        browserName: 'phantomjs'
+    }]
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -39,6 +39,21 @@ export function run (specs, wdioConfigPath) {
     })
 }
 
+export function runFeatures (features, wdioConfigPath) {
+    disableOutput()
+    if (!wdioConfigPath) {
+        wdioConfigPath = './test/fixtures/wdio.conf.cucumber.js'
+    }
+    const launcher = new Launcher(wdioConfigPath, {
+        specs: features.map(feature => `./test/fixtures/features/${feature}.feature`)
+    })
+
+    return launcher.run().then(() => {
+        enableOutput()
+        return getResults()
+    })
+}
+
 let logs, originalConsole
 
 function disableOutput () {

--- a/test/specs/cucumber-test-case.js
+++ b/test/specs/cucumber-test-case.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai'
+import { clean, runFeatures } from '../helper'
+
+describe('Cucumber test case', () => {
+    beforeEach(clean)
+
+    it('should add feature & scenario labels for cucumber test cases', () => {
+        return runFeatures(['passing']).then((results) => {
+            const result = results[0]
+            expect(result('test-case label[name="feature"]').eq(0).attr('value')).to.equal('A passing feature')
+            expect(result('test-case label[name="story"]').eq(0).attr('value')).to.equal('A passing scenario')
+        })
+    })
+})


### PR DESCRIPTION
When using cucumber, currently, tests do not have feature or scenario names attached to them leaving you with a flat list under the `Behaviors` tab:

<img width="629" alt="screen shot 2018-01-25 at 13 33 13" src="https://user-images.githubusercontent.com/1398186/35390927-f7fb930e-01d4-11e8-9396-83392b889770.png">

This change adds the correct labels to the `test:start` listener _if_ they are sent - e.g from the wdio-cucumber-framework:

<img width="628" alt="screen shot 2018-01-25 at 13 34 33" src="https://user-images.githubusercontent.com/1398186/35391044-5f00f792-01d5-11e8-97bc-e56e0a218284.png">
