### PR TITLE
Better Allure Api for users

### DIFF
--- a/lib/allureApi.js
+++ b/lib/allureApi.js
@@ -23,10 +23,3 @@ export function story (storyName) {
 function tellReporter (event, msg = {}) {
     process.send({ event, ...msg })
 }
-
-export default {
-    feature,
-    addEnvironment,
-    createAttachment,
-    story
-}

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,6 +1,7 @@
 import events from 'events'
 import Allure from 'allure-js-commons'
 import Step from 'allure-js-commons/beans/step'
+import * as AllureApi from './allureApi'
 
 function isEmpty (object) {
     return !object || Object.keys(object).length === 0
@@ -194,5 +195,9 @@ class AllureReporter extends events.EventEmitter {
         allure.addAttachment(name, JSON.stringify(json, null, '    '), 'application/json')
     }
 }
+
+Object.assign(AllureReporter, {
+    Api: AllureApi
+})
 
 export default AllureReporter

--- a/test/fixtures/specs/create-attachment.js
+++ b/test/fixtures/specs/create-attachment.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {createAttachment} = require('./../../../build/runtime')
+const {createAttachment} = require('./../../../build/reporter').Api
 
 describe('Suite with attachments', () => {
     it('Add attachment with plain text attachment', () => {

--- a/test/fixtures/specs/description.js
+++ b/test/fixtures/specs/description.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const addDescription = require('./../../../build/runtime').addDescription
+const { addDescription } = require('./../../../build/reporter').Api
 
 describe('Suite with description', () => {
     it('First case - default description type', () => {

--- a/test/fixtures/specs/environment.js
+++ b/test/fixtures/specs/environment.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const addEnvironment = require('./../../../build/runtime').addEnvironment
+const { addEnvironment } = require('./../../../build/reporter').Api
 
 describe('Suite with environments', () => {
     it('First case', () => {

--- a/test/fixtures/specs/feature.js
+++ b/test/fixtures/specs/feature.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const feature = require('./../../../build/runtime').feature
+const { feature } = require('./../../../build/reporter').Api
 
 describe('Suite with features', () => {
     it('First case', () => {

--- a/test/fixtures/specs/story.js
+++ b/test/fixtures/specs/story.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {story} = require('./../../../build/runtime')
+const {story} = require('./../../../build/reporter').Api
 
 describe('Suite with stories', () => {
     it('Test #1', () => {

--- a/test/fixtures/specs/test-case-multi-browser.js
+++ b/test/fixtures/specs/test-case-multi-browser.js
@@ -1,5 +1,5 @@
 'use strict'
-const feature = require('./../../../build/runtime').feature
+const { feature } = require('./../../../build/reporter').Api
 
 describe('A passing Suite', () => {
     it('with passing test', () => {


### PR DESCRIPTION
Users can now access Allure Api by :
```
import { Api } from 'wdio-allure-reporter';

it('test', () => {
    Api.feature('Feature');
  });
```

Another option is to move allure function to reporter: so then we could access it without Api wrapper:
```
import { feature} from 'wdio-allure-reporter';

it('test', () => {
    feature('Feature');
  });
```

What do you think about it ?