### PR TITLE
Update formatting of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,19 @@ exports.config = {
     // ...
     reporters: ['allure'],
     reporterOptions: {
-		allure: {
+        allure: {
             outputDir: 'allure-results',
             disableWebdriverStepsReporting: true,
             useCucumberStepReporter: false
-		}
-	},
-	// ...
+        }
+    },
+  // ...
 }
 ```
 
-`outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
-`disableWebdriverStepsReporting` - optional parameter(false by default), in order to log only custom steps to the reporter.
-`useCucumberStepReporter` - optional parameter(false by default), use this if you want to report Cucumber scenario steps as allure steps(instead of tests) in your report. DON'T use with mocha or jasmine - results will be unpredictable.
+- `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
+- `disableWebdriverStepsReporting` - optional parameter(false by default), in order to log only custom steps to the reporter.
+- `useCucumberStepReporter` - optional parameter(false by default), use this if you want to report Cucumber scenario steps as allure steps(instead of tests) in your report. DON'T use with mocha or jasmine - results will be unpredictable.
 
 ## Supported Allure API
 * `feature(featureName)` – assign feature to test


### PR DESCRIPTION
Formatting was a little off on the README after the latest update.

Before:
![image](https://user-images.githubusercontent.com/706039/37977848-3f398b36-31aa-11e8-9ba4-5f53c86a1cea.png)

After:
![image](https://user-images.githubusercontent.com/706039/37977830-3440b858-31aa-11e8-879b-33ae729bbde3.png)
