### PR TITLE
New option `disableWebdriverScreenshotsReporting`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ exports.config = {
 ```
 
 - `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
-- `disableWebdriverStepsReporting` - optional parameter(false by default), in order to log only custom steps to the reporter.
-- `disableWebdriverScreenshotsReporting` - optional parameter(false by default), in order to not attach screenshots to the reporter.
-- `useCucumberStepReporter` - optional parameter(false by default), use this if you want to report Cucumber scenario steps as allure steps(instead of tests) in your report. DON'T use with mocha or jasmine - results will be unpredictable.
+- `disableWebdriverStepsReporting` - optional parameter(`false` by default), in order to log only custom steps to the reporter.
+- `disableWebdriverScreenshotsReporting` - optional parameter(`false` by default), in order to not attach screenshots to the reporter.
+- `useCucumberStepReporter` - optional parameter(`false` by default), use this if you want to report Cucumber scenario steps as allure steps(instead of tests) in your report. DON'T use with mocha or jasmine - results will be unpredictable.
 
 ## Supported Allure API
 * `feature(featureName)` – assign feature to test

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ exports.config = {
         allure: {
             outputDir: 'allure-results',
             disableWebdriverStepsReporting: true,
+            disableWebdriverScreenshotsReporting: true,
             useCucumberStepReporter: false
         }
     },
@@ -45,6 +46,7 @@ exports.config = {
 
 - `outputDir` defaults to `./allure-results`. After a test run is complete, you will find that this directory has been populated with an `.xml` file for each spec, plus a number of `.txt` and `.png` files and other attachments.
 - `disableWebdriverStepsReporting` - optional parameter(false by default), in order to log only custom steps to the reporter.
+- `disableWebdriverScreenshotsReporting` - optional parameter(false by default), in order to not attach screenshots to the reporter.
 - `useCucumberStepReporter` - optional parameter(false by default), use this if you want to report Cucumber scenario steps as allure steps(instead of tests) in your report. DON'T use with mocha or jasmine - results will be unpredictable.
 
 ## Supported Allure API

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -192,7 +192,14 @@ class AllureReporter extends events.EventEmitter {
         }
 
         if (command.requestOptions.uri.path.match(/\/session\/[^/]*\/screenshot/) && command.body.value) {
-            allure.addAttachment('Screenshot', Buffer.from(command.body.value, 'base64'))
+            if (!this.options.disableWebdriverScreenshotsReporting) {
+                allure.addAttachment('Screenshot', Buffer.from(command.body.value, 'base64'))
+            } else if (!this.options.disableWebdriverStepsReporting) {
+                let oldValue = command.body.value
+                command.body.value = (typeof command.body.value === 'string' ? command.body.value.substr(0, 100) + '...' : command.body.value)
+                this.dumpJSON(allure, 'Response (screenshot)', command.body)
+                command.body.value = oldValue
+            }
         } else if (!this.options.disableWebdriverStepsReporting) {
             if (command.body) {
                 this.dumpJSON(allure, 'Response', command.body)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -194,11 +194,6 @@ class AllureReporter extends events.EventEmitter {
         if (command.requestOptions.uri.path.match(/\/session\/[^/]*\/screenshot/) && command.body.value) {
             if (!this.options.disableWebdriverScreenshotsReporting) {
                 allure.addAttachment('Screenshot', Buffer.from(command.body.value, 'base64'))
-            } else if (!this.options.disableWebdriverStepsReporting) {
-                let oldValue = command.body.value
-                command.body.value = (typeof command.body.value === 'string' ? command.body.value.substr(0, 100) + '...' : command.body.value)
-                this.dumpJSON(allure, 'Response (screenshot)', command.body)
-                command.body.value = oldValue
             }
         } else if (!this.options.disableWebdriverStepsReporting) {
             if (command.body) {

--- a/test/fixtures/wdio.conf/wdio.conf.mocha.noinfo.js
+++ b/test/fixtures/wdio.conf/wdio.conf.mocha.noinfo.js
@@ -1,0 +1,11 @@
+var baseConfig = require('./wdio.conf.js').getConfig()
+
+baseConfig.framework = 'mocha'
+baseConfig.mochaOpts = {
+    ui: 'bdd',
+    timeout: 20000
+}
+baseConfig.reporterOptions.allure.disableWebdriverStepsReporting = true
+baseConfig.reporterOptions.allure.disableWebdriverScreenshotsReporting = true
+
+exports.config = baseConfig

--- a/test/fixtures/wdio.conf/wdio.conf.mocha.noscr.js
+++ b/test/fixtures/wdio.conf/wdio.conf.mocha.noscr.js
@@ -1,0 +1,10 @@
+var baseConfig = require('./wdio.conf.js').getConfig()
+
+baseConfig.framework = 'mocha'
+baseConfig.mochaOpts = {
+    ui: 'bdd',
+    timeout: 20000
+}
+baseConfig.reporterOptions.allure.disableWebdriverScreenshotsReporting = true
+
+exports.config = baseConfig

--- a/test/specs/screenshot.js
+++ b/test/specs/screenshot.js
@@ -67,15 +67,6 @@ describe('Screenshots', () => {
         })
     })
 
-    it('should be replaced with plain text while disableWebdriverScreenshotsReporting enabled', () => {
-        return runMocha(['screenshot'], './test/fixtures/wdio.conf/wdio.conf.mocha.noscr.js').then((results) => {
-            expect(results).to.have.lengthOf(1)
-            expect(results[0]('test-case')).to.have.lengthOf(1)
-
-            expect(results[0]('test-case attachment[title="Response (screenshot)"]')).to.have.lengthOf(1)
-        })
-    })
-
     it('should not be reported while both disableWebdriverScreenshotsReporting and disableWebdriverStepsReporting are enabled', () => {
         return runMocha(['screenshot'], './test/fixtures/wdio.conf/wdio.conf.mocha.noinfo.js').then((results) => {
             expect(results).to.have.lengthOf(1)

--- a/test/specs/screenshot.js
+++ b/test/specs/screenshot.js
@@ -55,4 +55,33 @@ describe('Screenshots', () => {
             expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(1)
         })
     })
+
+    it('should not attach .png while disableWebdriverScreenshotsReporting enabled', () => {
+        return runMocha(['screenshot'], './test/fixtures/wdio.conf/wdio.conf.mocha.noscr.js').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            expect(results[0]('test-case')).to.have.lengthOf(1)
+
+            const screenshotFiles = getResultFiles('png')
+            expect(screenshotFiles, 'screenshot file is exist').to.have.lengthOf(0)
+            expect(results[0]('test-case attachment[title="Screenshot"]')).to.have.lengthOf(0)
+        })
+    })
+
+    it('should be replaced with plain text while disableWebdriverScreenshotsReporting enabled', () => {
+        return runMocha(['screenshot'], './test/fixtures/wdio.conf/wdio.conf.mocha.noscr.js').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            expect(results[0]('test-case')).to.have.lengthOf(1)
+
+            expect(results[0]('test-case attachment[title="Response (screenshot)"]')).to.have.lengthOf(1)
+        })
+    })
+
+    it('should not be reported while both disableWebdriverScreenshotsReporting and disableWebdriverStepsReporting are enabled', () => {
+        return runMocha(['screenshot'], './test/fixtures/wdio.conf/wdio.conf.mocha.noinfo.js').then((results) => {
+            expect(results).to.have.lengthOf(1)
+            expect(results[0]('test-case')).to.have.lengthOf(1)
+
+            expect(results[0]('test-case attachment[title="Response (screenshot)"]')).to.have.lengthOf(0)
+        })
+    })
 })


### PR DESCRIPTION
New option `disableWebdriverScreenshotsReporting` - optional parameter (false by default), in order to not attach screenshots to the reporter. If turned on - it's only log truncated response instead.

Usefull for WDIO Visual Regression Service, because it's generate a lot of small screenshots. They greatly increase allure folder size.