### PR TITLE
Fix pending test reporting

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -121,10 +121,10 @@ class AllureReporter extends events.EventEmitter {
 
     testPending (test) {
         const allure = this.getAllure(test.cid)
-        if (allure.getCurrentTest()) {
+        if (allure.getCurrentTest() && allure.getCurrentTest().status !== 'pending') {
             allure.endCase('pending')
         } else {
-            this.getAllure(test.cid).pendingCase(test.title)
+            allure.pendingCase(test.title)
         }
     }
 

--- a/test/fixtures/specs/several-pendings.js
+++ b/test/fixtures/specs/several-pendings.js
@@ -1,0 +1,17 @@
+const expect = require('chai').expect
+
+describe('A pending Suite', () => {
+    it.skip('1. this is a skipped test without any code', function () {
+    })
+
+    it.skip('2. this is another skipped test without any code', function () {
+    })
+
+    it('3. this is an enabled test that has a successfull assert', function () {
+        expect('foo', 'foo should equal foo').to.contain('foo')
+    })
+
+    it('4. this is an enabled test that has a failed assert', function () {
+        expect('foo', 'foo should equal foo').to.contain('foo2')
+    })
+})

--- a/test/specs/test-case-pending.js
+++ b/test/specs/test-case-pending.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai'
+import { clean, runMocha } from '../helper'
+
+describe('test cases', () => {
+    beforeEach(clean)
+
+    it('should detect pending test cases', () => {
+        return runMocha(['pending']).then((results) => {
+            expect(results).to.have.lengthOf(1)
+            const result = results[0]
+
+            expect(result('ns2\\:test-suite > name').text()).to.be.equal('A pending Suite')
+            expect(result('test-case > name').eq(0).text()).to.be.equal('pending test')
+            expect(result('test-case').eq(0).attr('status')).to.be.equal('pending')
+
+            expect(result('test-case').eq(1).attr('start')).to.be.equal(result('test-case').eq(1).attr('stop'))
+        })
+    })
+
+    it('should detect two pending test cases', () => {
+        return runMocha(['several-pendings']).then((results) => {
+            expect(results).to.have.lengthOf(1)
+            const result = results[0]
+
+            expect(result('test-case > name').eq(0).text()).to.be.equal('1. this is a skipped test without any code')
+            expect(result('test-case').eq(0).attr('status')).to.be.equal('pending')
+            expect(result('test-case > name').eq(1).text()).to.be.equal('2. this is another skipped test without any code')
+            expect(result('test-case').eq(1).attr('status')).to.be.equal('pending')
+            expect(result('test-case').eq(2).attr('status')).to.be.equal('passed')
+            expect(result('test-case').eq(3).attr('status')).to.be.equal('failed')
+        })
+    })
+})

--- a/test/specs/test-case.js
+++ b/test/specs/test-case.js
@@ -40,19 +40,6 @@ describe('test cases', () => {
         })
     })
 
-    it('should detect pending test cases', () => {
-        return runMocha(['pending']).then((results) => {
-            expect(results).to.have.lengthOf(1)
-            const result = results[0]
-
-            expect(result('ns2\\:test-suite > name').text()).to.be.equal('A pending Suite')
-            expect(result('test-case > name').eq(0).text()).to.be.equal('pending test')
-            expect(result('test-case').eq(0).attr('status')).to.be.equal('pending')
-
-            expect(result('test-case').eq(1).attr('start')).to.be.equal(result('test-case').eq(1).attr('stop'))
-        })
-    })
-
     it('should detect analytics labels in test case', () => {
         return runMocha(['passing']).then((results) => {
             expect(results).to.have.lengthOf(1)


### PR DESCRIPTION
When several pending tests are exists in file, only one was reported

See https://stackoverflow.com/questions/51615935/allure-report-ignores-multiple-skipped-mocha-tests