### PR TITLE
Add thread label to help Allure timeline works correctly

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -96,6 +96,7 @@ class AllureReporter extends events.EventEmitter {
         // Analytics labels More: https://github.com/allure-framework/allure2/blob/master/Analytics.md
         currentTest.addLabel('language', 'javascript')
         currentTest.addLabel('framework', 'wdio')
+        currentTest.addLabel('thread', test.cid)
     }
 
     testPass (test) {

--- a/test/specs/test-case.js
+++ b/test/specs/test-case.js
@@ -53,4 +53,15 @@ describe('test cases', () => {
             expect(result('test-case label[name="framework"]').eq(0).attr('value')).to.be.equal('wdio')
         })
     })
+
+    it('should detect thread', () => {
+        return runMocha(['passing']).then((results) => {
+            expect(results).to.have.lengthOf(1)
+            const result = results[0]
+
+            expect(result('ns2\\:test-suite > name').text()).to.be.equal('A passing Suite')
+            expect(result('test-case > name').text()).to.be.equal('with passing test')
+            expect(result('test-case label[name="thread"]')).to.have.lengthOf(1)
+        })
+    })
 })


### PR DESCRIPTION
Now Allure timeline tab shows test runs in one thread.
With this we help reporter shows test execution timeline correct.