### PR TITLE
Handle test failures where 'err.name' and 'err.stack' are undefined

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,10 +12,10 @@ export function getTestStatus (test, config) {
     if (test.err.name) {
         status = test.err.name === 'AssertionError' ? FAILED : BROKEN
     } else if (test.err.stack) {
-        var stackTrace = test.err.stack.trim();
-        status = stackTrace.startsWith('AssertionError') ? FAILED : BROKEN;
+        var stackTrace = test.err.stack.trim()
+        status = stackTrace.startsWith('AssertionError') ? FAILED : BROKEN
     } else {
-        status = BROKEN;
+        status = BROKEN
     }
     return status
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,9 +11,11 @@ export function getTestStatus (test, config) {
 
     if (test.err.name) {
         status = test.err.name === 'AssertionError' ? FAILED : BROKEN
+    } else if (test.err.stack) {
+        var stackTrace = test.err.stack.trim();
+        status = stackTrace.startsWith('AssertionError') ? FAILED : BROKEN;
     } else {
-        const stackTrace = test.err.stack.trim()
-        status = stackTrace.startsWith('AssertionError') ? FAILED : BROKEN
+        status = BROKEN;
     }
     return status
 }


### PR DESCRIPTION
This is a patch for v0.8.3.

The reporter throws an exception when encountering failures with errors missing a `name` and `stack` property (like cucumber-js's "Multiple step definitions match" error).

When wdio-allure-reporter encounters an error event like this:

```js
{ event: 'test:fail',
  type: 'test',
  file: '../x.feature',
  err: { message: 'Multiple step definitions match:\n...' },
```
then the following exception is thrown:
```bash
/.../node_modules/webdriverio/build/lib/utils/BaseReporter.js:351
                        throw _iteratorError;
                        ^

TypeError: Cannot read property 'trim' of undefined
    at getTestStatus (/.../node_modules/wdio-allure-reporter/build/utils.js:31:41)
    at AllureReporter.cucumberTestFail (/.../node_modules/wdio-allure-reporter/build/reporter.js:381:55)
    at emitOne (events.js:116:13)
    at AllureReporter.emit (events.js:211:7)
    at BaseReporter.handleEvent (/.../node_modules/webdriverio/build/lib/utils/BaseReporter.js:339:35)
    at Launcher.messageHandler (/.../node_modules/webdriverio/build/lib/launcher.js:688:28)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at emit (internal/child_process.js:762:12)
    at _combinedTickCallback (internal/process/next_tick.js:142:11)
error Command failed with exit code 1.
```
